### PR TITLE
[PARALLEL] Pull: include error message in warnings/errors

### DIFF
--- a/pkg/compose/pull.go
+++ b/pkg/compose/pull.go
@@ -200,18 +200,20 @@ func (s *composeService) pullServiceImage(ctx context.Context, service types.Ser
 	// then the status should be warning instead of error
 	if err != nil && service.Build != nil {
 		w.Event(progress.Event{
-			ID:     service.Name,
-			Status: progress.Warning,
-			Text:   "Warning",
+			ID:         service.Name,
+			Status:     progress.Warning,
+			Text:       "Warning",
+			StatusText: err.Error(),
 		})
 		return "", WrapCategorisedComposeError(err, PullFailure)
 	}
 
 	if err != nil {
 		w.Event(progress.Event{
-			ID:     service.Name,
-			Status: progress.Error,
-			Text:   "Error",
+			ID:         service.Name,
+			Status:     progress.Error,
+			Text:       "Error",
+			StatusText: err.Error(),
 		})
 		return "", WrapCategorisedComposeError(err, PullFailure)
 	}

--- a/pkg/compose/pull.go
+++ b/pkg/compose/pull.go
@@ -169,6 +169,14 @@ func imageAlreadyPresent(serviceImage string, localImages map[string]string) boo
 	return ok && tagged.Tag() != "latest"
 }
 
+func getUnwrappedErrorMessage(err error) string {
+	derr := errors.Unwrap(err)
+	if derr != nil {
+		return getUnwrappedErrorMessage(derr)
+	}
+	return err.Error()
+}
+
 func (s *composeService) pullServiceImage(ctx context.Context, service types.ServiceConfig,
 	configFile driver.Auth, w progress.Writer, quietPull bool, defaultPlatform string) (string, error) {
 	w.Event(progress.Event{
@@ -203,7 +211,7 @@ func (s *composeService) pullServiceImage(ctx context.Context, service types.Ser
 			ID:         service.Name,
 			Status:     progress.Warning,
 			Text:       "Warning",
-			StatusText: err.Error(),
+			StatusText: getUnwrappedErrorMessage(err),
 		})
 		return "", WrapCategorisedComposeError(err, PullFailure)
 	}
@@ -213,7 +221,7 @@ func (s *composeService) pullServiceImage(ctx context.Context, service types.Ser
 			ID:         service.Name,
 			Status:     progress.Error,
 			Text:       "Error",
-			StatusText: err.Error(),
+			StatusText: getUnwrappedErrorMessage(err),
 		})
 		return "", WrapCategorisedComposeError(err, PullFailure)
 	}


### PR DESCRIPTION
Copy of https://github.com/docker/compose/pull/11555 so I can run CI without waiting for someone to approve it.